### PR TITLE
[BUGFIX] Allow vite to serve hidden files

### DIFF
--- a/nginx_full/vite.conf
+++ b/nginx_full/vite.conf
@@ -15,15 +15,6 @@ server {
     error_log /dev/stdout info;
     access_log off;
 
-    # Prevent clients from accessing hidden files (starting with a dot)
-    # This is particularly important if you store .htpasswd files in the site hierarchy
-    # Access to `/.well-known/` is allowed.
-    # https://www.mnot.net/blog/2010/04/07/well-known
-    # https://tools.ietf.org/html/rfc5785
-    location ~* /\.(?!well-known\/) {
-        deny all;
-    }
-
     location /vite-server-not-running.html {
         root /mnt/ddev_config/vite/;
     }

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -33,6 +33,8 @@ error_checks() {
 
 health_checks() {
   ddev exec "curl -s -D - -o /dev/null https://vite.${PROJNAME}.ddev.site/@vite/client" | grep "HTTP/2 200"
+  # Test if vite can serve hidden files from node_modules
+  ddev exec "curl -s https://vite.${PROJNAME}.ddev.site/node_modules/.vite/deps/_metadata.json" | grep "\"chunks\": {}"
 }
 
 teardown() {


### PR DESCRIPTION
The "deny all" snippet was copied from the default nginx configuration to the reverse proxy configuration for vite. However, vite needs to serve files from node_modules/.vite/* to work properly.

As this add-on is purely a local developer add-on and not expected to be run on production systems, it is not critical to serve dotfiles.